### PR TITLE
Add root workspace scripts for Argumind app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # LSATProject
+
+This repository hosts the Argumind web application. The Next.js project lives in the `argumind/` workspace.
+
+## Getting started
+
+1. Install dependencies (this installs the `argumind` workspace packages):
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+The helper scripts defined at the repository root simply forward to the equivalent scripts inside the `argumind` workspace, so you can also run `npm run build`, `npm run lint`, etc. at the root.

--- a/argumind/.env.example
+++ b/argumind/.env.example
@@ -1,0 +1,9 @@
+# PostgreSQL connection string will be provided when the database is ready.
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE"
+
+# Google OAuth credentials will be added in future iterations.
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
+
+# NextAuth secret for session encryption.
+NEXTAUTH_SECRET="replace-with-strong-secret"

--- a/argumind/.eslintrc.json
+++ b/argumind/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/argumind/.gitignore
+++ b/argumind/.gitignore
@@ -1,0 +1,16 @@
+node_modules
+.next
+out
+.env
+.env.local
+.env.development
+.env.production
+.env.test
+prisma/dev.db
+
+# Editor directories and files
+.vscode
+.idea
+*.swp
+*.log
+.DS_Store

--- a/argumind/README.md
+++ b/argumind/README.md
@@ -1,0 +1,37 @@
+# Argumind Web
+
+Argumind is an AI-assisted LSAT preparation experience that will seamlessly connect web and mobile. This repository contains the Next.js web app foundation with NextAuth, Prisma, TypeScript, and Tailwind CSS.
+
+## Getting started
+
+You can work entirely from the repository root thanks to the npm workspace configuration:
+
+```bash
+npm install
+npm run dev
+```
+
+If you prefer to manage the app directly inside the `argumind/` directory, the following commands are equivalent:
+
+1. Install dependencies:
+   ```bash
+   cd argumind
+   npm install
+   ```
+2. Copy the environment template and provide credentials when they become available:
+   ```bash
+   cp .env.example .env.local
+   ```
+3. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+> ℹ️ Database connectivity is intentionally deferred for this iteration. API routes and authentication flows are scaffolded but return placeholder responses until PostgreSQL is configured.
+
+## Features
+
+- Minimalist landing page introducing Argumind
+- Client-side sign-in and sign-up forms with Zod-powered validation
+- Google sign-in entry point (pending OAuth credentials)
+- Prisma schema and NextAuth configuration ready for future database integration

--- a/argumind/next-env.d.ts
+++ b/argumind/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/argumind/next.config.mjs
+++ b/argumind/next.config.mjs
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '2mb'
+    }
+  }
+};
+
+export default nextConfig;

--- a/argumind/package.json
+++ b/argumind/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "argumind",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "postinstall": "prisma generate"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "@prisma/client": "^5.15.0",
+    "clsx": "^2.1.1",
+    "next": "^14.2.3",
+    "next-auth": "^4.24.6",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.51.5",
+    "zod": "^3.23.8",
+    "tailwind-merge": "^2.2.1",
+    "react-icons": "^5.2.1",
+    "@next-auth/prisma-adapter": "^1.0.7"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "postcss": "^8.4.38",
+    "prisma": "^5.15.0",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.5.4"
+  }
+}

--- a/argumind/postcss.config.mjs
+++ b/argumind/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/argumind/prisma/schema.prisma
+++ b/argumind/prisma/schema.prisma
@@ -1,0 +1,55 @@
+/// Placeholder schema for future database implementation.
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String   @id @default(cuid())
+  name          String?
+  email         String?  @unique
+  emailVerified DateTime?
+  image         String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  accounts      Account[]
+  sessions      Session[]
+}
+
+model Account {
+  id                String   @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?  @db.Text
+  access_token      String?  @db.Text
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?  @db.Text
+  session_state     String?
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}

--- a/argumind/src/app/api/auth/[...nextauth]/route.ts
+++ b/argumind/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/argumind/src/app/globals.css
+++ b/argumind/src/app/globals.css
@@ -1,0 +1,31 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+}
+
+a {
+  @apply text-primary-400 hover:text-primary-300 transition;
+}
+
+.btn-primary {
+  @apply inline-flex items-center justify-center rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500;
+}
+
+.input {
+  @apply w-full rounded-lg border border-slate-700 bg-slate-900/60 px-4 py-2 text-sm text-slate-100 placeholder:text-slate-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/40;
+}
+
+.label {
+  @apply text-sm font-medium text-slate-200;
+}
+
+.error-text {
+  @apply text-xs text-red-400 mt-1;
+}

--- a/argumind/src/app/layout.tsx
+++ b/argumind/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], display: "swap" });
+
+export const metadata: Metadata = {
+  title: "Argumind | LSAT Prep Reimagined",
+  description: "Argumind is your AI-powered LSAT preparation companion across web and mobile."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="bg-slate-950">
+      <body className={`${inter.className} bg-gradient-to-b from-slate-950 via-slate-940 to-slate-950 min-h-screen`}>{children}</body>
+    </html>
+  );
+}

--- a/argumind/src/app/page.tsx
+++ b/argumind/src/app/page.tsx
@@ -1,0 +1,60 @@
+import { AuthForm } from "@/components/auth/auth-form";
+
+const features = [
+  {
+    title: "Adaptive Prep",
+    description: "AI-crafted logic drills that learn from every response."
+  },
+  {
+    title: "Seamless Sync",
+    description: "Progress transfers instantly between web and mobile."
+  },
+  {
+    title: "Mentor Insights",
+    description: "Conversational feedback that keeps you exam-ready."
+  }
+];
+
+export default function HomePage() {
+  return (
+    <main className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-20 px-6 pb-20 pt-24 sm:pt-32">
+      <div className="grid items-center gap-16 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-8 text-left">
+          <span className="inline-flex items-center gap-2 rounded-full border border-primary-500/40 bg-primary-500/10 px-4 py-1 text-xs uppercase tracking-[0.4em] text-primary-200">
+            Argumind
+          </span>
+          <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl md:text-6xl">
+            Master the LSAT with an AI co-pilot that knows how you think.
+          </h1>
+          <p className="max-w-xl text-base text-slate-300 sm:text-lg">
+            Argumind pairs cutting-edge AI with proven reasoning frameworks to sharpen your logic, pacing, and confidence. Start on the web and stay in sync with our upcoming mobile app.
+          </p>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <a className="btn-primary" href="#get-started">
+              Get started
+            </a>
+            <a className="text-sm font-medium text-slate-300 hover:text-white" href="#learn-more">
+              Learn more
+            </a>
+          </div>
+        </div>
+        <div className="space-y-4" id="get-started">
+          <AuthForm />
+        </div>
+      </div>
+
+      <section className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3" id="learn-more">
+        {features.map((feature) => (
+          <div key={feature.title} className="rounded-3xl border border-slate-800/80 bg-slate-950/40 p-8 shadow-lg shadow-black/30">
+            <h3 className="text-lg font-semibold text-white">{feature.title}</h3>
+            <p className="mt-3 text-sm text-slate-300">{feature.description}</p>
+          </div>
+        ))}
+      </section>
+
+      <footer className="border-t border-slate-800/60 pt-8 text-sm text-slate-500">
+        <p>© {new Date().getFullYear()} Argumind Labs. All rights reserved.</p>
+      </footer>
+    </main>
+  );
+}

--- a/argumind/src/components/auth/auth-form.tsx
+++ b/argumind/src/components/auth/auth-form.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { signInSchema, signUpSchema, type SignInValues, type SignUpValues } from "@/lib/validators";
+import { cn } from "@/lib/utils";
+import { GoogleSignInButton } from "./google-button";
+
+const formTitles = {
+  signIn: "Welcome back",
+  signUp: "Create your account"
+} as const;
+
+type Mode = keyof typeof formTitles;
+
+type BaseFormValues = SignInValues & { name?: string; confirmPassword?: string };
+
+type AuthFormProps = {
+  mode?: Mode;
+};
+
+export function AuthForm({ mode: initialMode = "signIn" }: AuthFormProps) {
+  const [mode, setMode] = useState<Mode>(initialMode);
+  const schema = useMemo(() => (mode === "signIn" ? signInSchema : signUpSchema), [mode]);
+
+  const {
+    handleSubmit,
+    register,
+    reset,
+    formState: { errors, isSubmitting }
+  } = useForm<BaseFormValues>({
+    resolver: zodResolver(schema),
+    mode: "onBlur"
+  });
+
+  useEffect(() => {
+    reset();
+  }, [mode, reset]);
+
+  const onSubmit = async (values: BaseFormValues) => {
+    const parsed = schema.parse(values);
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    console.info("Submitted", mode, parsed);
+    alert(`Validation succeeded for ${mode === "signIn" ? "sign in" : "sign up"}! Check the console for payload.`);
+  };
+
+  return (
+    <div className="w-full max-w-md rounded-3xl border border-slate-800/60 bg-slate-950/60 p-8 backdrop-blur">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm uppercase tracking-[0.3em] text-primary-300/80">Argumind</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{formTitles[mode]}</h2>
+          <p className="mt-1 text-sm text-slate-400">
+            {mode === "signIn" ? "Sign in to access your personalized LSAT prep." : "Start building smarter logic with Argumind."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setMode(mode === "signIn" ? "signUp" : "signIn")}
+          className="text-sm font-medium text-primary-300 hover:text-primary-200"
+        >
+          {mode === "signIn" ? "Need an account?" : "Have an account?"}
+        </button>
+      </div>
+
+      <div className="mt-8 space-y-3">
+        <GoogleSignInButton />
+        <div className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-slate-500">
+          <span className="h-px flex-1 bg-slate-800" />
+          <span>Or</span>
+          <span className="h-px flex-1 bg-slate-800" />
+        </div>
+      </div>
+
+      <form className="mt-6 space-y-6" onSubmit={handleSubmit(onSubmit)} noValidate>
+        {mode === "signUp" && (
+          <div>
+            <label className="label" htmlFor="name">
+              Full name
+            </label>
+            <input id="name" type="text" autoComplete="name" className="input mt-1" {...register("name" as const)} />
+            {errors?.name && <p className="error-text">{errors.name.message}</p>}
+          </div>
+        )}
+
+        <div>
+          <label className="label" htmlFor="email">
+            Email
+          </label>
+          <input id="email" type="email" autoComplete="email" className="input mt-1" {...register("email" as const)} />
+          {errors?.email && <p className="error-text">{errors.email.message}</p>}
+        </div>
+
+        <div>
+          <label className="label" htmlFor="password">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            autoComplete={mode === "signIn" ? "current-password" : "new-password"}
+            className="input mt-1"
+            {...register("password" as const)}
+          />
+          {errors?.password && <p className="error-text">{errors.password.message}</p>}
+        </div>
+
+        {mode === "signUp" && (
+          <div>
+            <label className="label" htmlFor="confirmPassword">
+              Confirm password
+            </label>
+            <input id="confirmPassword" type="password" autoComplete="new-password" className="input mt-1" {...register("confirmPassword" as const)} />
+            {errors?.confirmPassword && <p className="error-text">{errors.confirmPassword.message}</p>}
+          </div>
+        )}
+
+        <button type="submit" className={cn("btn-primary w-full", isSubmitting && "opacity-80")} disabled={isSubmitting}>
+          {isSubmitting ? "Checking..." : mode === "signIn" ? "Sign in" : "Create account"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/argumind/src/components/auth/google-button.tsx
+++ b/argumind/src/components/auth/google-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { FcGoogle } from "react-icons/fc";
+
+export function GoogleSignInButton() {
+  const handleClick = () => {
+    alert("Google sign-in will be available soon.");
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex w-full items-center justify-center gap-3 rounded-full border border-slate-700 bg-white/5 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+    >
+      <FcGoogle className="text-lg" /> Continue with Google
+    </button>
+  );
+}

--- a/argumind/src/lib/auth.ts
+++ b/argumind/src/lib/auth.ts
@@ -1,0 +1,18 @@
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import GoogleProvider from "next-auth/providers/google";
+import type { NextAuthOptions } from "next-auth";
+import { prisma } from "./prisma";
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "placeholder",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "placeholder"
+    })
+  ],
+  session: {
+    strategy: "database"
+  },
+  debug: process.env.NODE_ENV === "development"
+};

--- a/argumind/src/lib/prisma.ts
+++ b/argumind/src/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"]
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/argumind/src/lib/utils.ts
+++ b/argumind/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/argumind/src/lib/validators.ts
+++ b/argumind/src/lib/validators.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const signInSchema = z.object({
+  email: z.string().min(1, "Email is required").email("Enter a valid email"),
+  password: z.string().min(8, "Password must be at least 8 characters")
+});
+
+export const signUpSchema = z
+  .object({
+    name: z.string().min(2, "Please enter your full name"),
+    email: z.string().min(1, "Email is required").email("Enter a valid email"),
+    password: z
+      .string()
+      .min(8, "Password must be at least 8 characters")
+      .regex(/[A-Z]/, "Include at least one uppercase letter")
+      .regex(/[a-z]/, "Include at least one lowercase letter")
+      .regex(/[0-9]/, "Include at least one number"),
+    confirmPassword: z.string().min(1, "Please confirm your password")
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "Passwords must match"
+  });
+
+export type SignInValues = z.infer<typeof signInSchema>;
+export type SignUpValues = z.infer<typeof signUpSchema>;

--- a/argumind/tailwind.config.ts
+++ b/argumind/tailwind.config.ts
@@ -1,0 +1,33 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: "#f4f8ff",
+          100: "#e6f0ff",
+          200: "#c4daff",
+          300: "#9ec2ff",
+          400: "#6a9cff",
+          500: "#3d74ff",
+          600: "#2256e6",
+          700: "#183d99",
+          800: "#122d73",
+          900: "#0b1d4d"
+        }
+      },
+      fontFamily: {
+        sans: ["Inter", "var(--font-sans)", "system-ui", "sans-serif"]
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/argumind/tsconfig.json
+++ b/argumind/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lsatproject",
+  "private": true,
+  "workspaces": [
+    "argumind"
+  ],
+  "scripts": {
+    "dev": "npm run dev --workspace argumind",
+    "build": "npm run build --workspace argumind",
+    "start": "npm run start --workspace argumind",
+    "lint": "npm run lint --workspace argumind"
+  }
+}


### PR DESCRIPTION
## Summary
- configure the repository root as an npm workspace that forwards scripts to the Argumind Next.js app
- document the root-level workflow in both the top-level README and the Argumind app README

## Testing
- npm install *(fails: npm registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e49fd01cd48325866ca7f39cd5544b